### PR TITLE
Allow for SuppressKeyPress feedback

### DIFF
--- a/KeyboardInterceptor.cs
+++ b/KeyboardInterceptor.cs
@@ -114,6 +114,7 @@ namespace Open.WinKeyboardHook
                             RaiseKeyUpEvent(keyEventArgs);
                             break;
                     }
+                    if(keyEventArgs.SuppressKeyPress) return new IntPtr(1);
                 }
             }
             finally


### PR DESCRIPTION
Once a key event is handled and the user sets SuppressKeyPress = true,
the return value for the hook handler should return 1 so that the event
is not sent to the underlying control
