### PR TITLE
Should not use ToUnicodeEx in WM_SYSKEYDOWN

### DIFF
--- a/KeyboardInterceptor.cs
+++ b/KeyboardInterceptor.cs
@@ -93,6 +93,8 @@ namespace Open.WinKeyboardHook
                     switch (intParam)
                     {
                         case NativeMethods.WM_SYSKEYDOWN:
+                            RaiseKeyDownEvent(keyEventArgs);
+                            break;
                         case NativeMethods.WM_KEYDOWN:
                             RaiseKeyDownEvent(keyEventArgs);
 


### PR DESCRIPTION
Unexpected characters(♠) generated with press Alt+Right.
The behavior triggered by ToUnicodeEx.

ToUnicodeEx changes kernel-mode keyboard buffer.
Should not use ToUnicodeEx in WM_SYSKEYDOWN prevents side-effect.

See Remarks in https://msdn.microsoft.com/ja-jp/library/windows/desktop/ms646322(v=vs.85).aspx