### PR TITLE
Manages AltGr key state

### DIFF
--- a/KeyboardInterceptor.cs
+++ b/KeyboardInterceptor.cs
@@ -66,8 +66,7 @@ namespace Open.WinKeyboardHook
                 {
                     var moduleHandler = NativeMethods.GetModuleHandle(module.ModuleName);
 
-                    _previousKeyboardHandler = NativeMethods.SetWindowsHookEx(
-                        NativeMethods.WH_KEYBOARD_LL, _keyboardProc, moduleHandler, 0);
+                    _previousKeyboardHandler = NativeMethods.SetWindowsHookEx(NativeMethods.WH_KEYBOARD_LL, _keyboardProc, moduleHandler, 0);
 
                     if (_previousKeyboardHandler.IsInvalid)
                     {
@@ -149,6 +148,7 @@ namespace Open.WinKeyboardHook
         {
             return IsKeyPressed(NativeMethods.VK_LCONTROL) || IsKeyPressed(NativeMethods.VK_RCONTROL);
         }
+
         private static bool IsShiftKeyDown()
         {
             return IsKeyPressed(NativeMethods.VK_LSHIFT) || IsKeyPressed(NativeMethods.VK_RSHIFT);
@@ -197,17 +197,16 @@ namespace Open.WinKeyboardHook
             if (count > 0)
             {
                 result = buffer.ToString(0, count);
+                
+                if (_lastDeadKey == null) return result;
 
-                if (_lastDeadKey != null)
-                {
-                    ToUnicode(_lastDeadKey.KeyCode,
-                              _lastDeadKey.ScanCode,
-                              _lastDeadKey.KeyboardState,
-                              buffer,
-                              layout);
+                // Reload diacritic character or accent
+                ToUnicode(_lastDeadKey.KeyCode, _lastDeadKey.ScanCode, _lastDeadKey.KeyboardState, buffer, layout);
+                count = ToUnicode((Keys)info.KeyCode, info.ScanCode, keyState, buffer, layout);
 
-                    _lastDeadKey = null;
-                }
+                result = buffer.ToString(0, count);
+
+                _lastDeadKey = null;
             }
             else if (count < 0)
             {
@@ -257,8 +256,8 @@ namespace Open.WinKeyboardHook
         private sealed class DeadKeyInfo
         {
             public readonly Keys KeyCode;
-            public readonly Byte[] KeyboardState;
-            public readonly UInt32 ScanCode;
+            public readonly byte[] KeyboardState;
+            public readonly uint ScanCode;
 
             public DeadKeyInfo(KBDLLHOOKSTRUCT info, byte[] keyState)
             {

--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -94,11 +94,10 @@ namespace Open.WinKeyboardHook
         internal static extern uint MapVirtualKey(uint uCode, uint uMapType);
 
         [DllImport("user32.dll")]
-        internal static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[]
-                                                                                  lpKeyState,
+        internal static extern int ToUnicodeEx(uint wVirtKey, uint wScanCode, byte[] lpKeyState,
                                                [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff,
                                                int cchBuff, uint wFlags, IntPtr dwhkl);
-
+        
         [DllImport("user32.dll")]
         internal static extern IntPtr GetForegroundWindow();
 

--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -48,6 +48,7 @@ namespace Open.WinKeyboardHook
     internal static class NativeMethods
     {
         internal const int WH_KEYBOARD_LL = 0x0D;
+        internal const int WH_KEYBOARD = 0x02;
 
         internal const byte VK_CAPITAL = 0x14;
         internal const byte VK_CONTROL = 0x11;


### PR DESCRIPTION
I fixed use of AltGr keystroke. 
There is still a problem with few characters. For example I cannot enter 'ñ'. Code does not like upping key with dead keys. Problem is similar when I want 'Ê' character: shift key is pressed down in between '^' and 'E'. I think it should be a new issue.

I simplified some lines too.